### PR TITLE
エラーの検出方法について

### DIFF
--- a/17745149_chk.sh
+++ b/17745149_chk.sh
@@ -3,7 +3,7 @@
 tmp=/tmp/$$
 
 ERROR_EXIT () {
-	echo "$1" > &2
+	echo "$1" > &2 # &は"2"ではなく">"にくっつく。$1 >& 2
 	rm -f $tmp-*
 	exit 1
 }
@@ -11,7 +11,7 @@ ERROR_EXIT () {
 #TEST#
 ######
 echo aaa 120 NG > $tmp-ans
-./17745149.sh aaa 120 > $tmp-out && ERROR_EXIT "TEST-1"
+./17745149.sh aaa 120 > $tmp-out && ERROR_EXIT "TEST-1" # 17745149.shはエラーがあっても無視して進むのでここはおかしい
 diff $tmp-ans $tmp-out || ERROR_EXIT "TEST1-2"
 diff $tmp-ans $tmp-out && echo "TEST OK"
 


### PR DESCRIPTION
6行目の表記が違う。

また、そもそも17745149.shは入力が変でもそのまま実行し、最後の行まで進んでexit 0をしてしまう。
そのため、14行目では成功扱いとなり、TEST-1でエラーとなる。